### PR TITLE
Fix typo in build outputs

### DIFF
--- a/packages/project-editor/build/build.ts
+++ b/packages/project-editor/build/build.ts
@@ -169,7 +169,7 @@ async function generateFile(
             projectStore.outputSectionsStore.write(
                 Section.OUTPUT,
                 MessageType.INFO,
-                `File "${filePath}.map" builded`
+                `File "${filePath}.map" built`
             );
         }
     }
@@ -177,7 +177,7 @@ async function generateFile(
     projectStore.outputSectionsStore.write(
         Section.OUTPUT,
         MessageType.INFO,
-        `File "${filePath}" builded`
+        `File "${filePath}" built`
     );
 
     return parts;

--- a/packages/project-editor/features/extension-definitions/build.ts
+++ b/packages/project-editor/features/extension-definitions/build.ts
@@ -189,7 +189,7 @@ export async function extensionDefinitionBuild(projectStore: ProjectStore) {
             projectStore.outputSectionsStore.write(
                 Section.OUTPUT,
                 MessageType.INFO,
-                `Instrument definition file "${idfFileName}" builded.`
+                `Instrument definition file "${idfFileName}" built.`
             );
         }
     }


### PR DESCRIPTION
Fix the description on a build output from "foo builded" to "foo built", which is the usual way of writing this in english. Just makes it look nicer!